### PR TITLE
Add request annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,18 +51,42 @@ By default, request specs get recorded and written to a `.apib` file afterwards.
 Rspec-apib is trying to make sense of the test run and generates a meaningful
 documentation out of it.
 
-* **Disable single examples:** Add `apib: false` to the examples meta data
+- **Disable single examples:** Add `apib: false` to the examples meta data
+
   ```ruby
   it 'does something', apib: false do
     # ...
   end
   ```
 
-* **Custom example description:** Add an *apib* comment above the example
-  ```ruby
+- **Custom example description:** Add an _apib_ comment above the example
+  You can add a description for the request, response or both.
+
+  Description only for the request
+
+  ````ruby
   # Not contained in the description
   #
-  # --- apib
+  # --- apib:request
+  # Some awesome description of the request
+  #
+  # ```json
+  # {}
+  # ```
+  # ---
+  #
+  # Not contained in the description
+  #
+  it 'has a custom description' do
+    # ...
+  end
+  ````
+
+  Description only for the response
+
+  ````ruby
+  # Not contained in the description
+  # -- apib:response
   # Some awesome description of the response
   #
   # ```json
@@ -75,7 +99,30 @@ documentation out of it.
   it 'has a custom description' do
     # ...
   end
-  ```
+  ````
+
+  Description for both request and response
+
+  ````ruby
+  # Not contained in the description
+  #
+  # --- apib:request
+  # Some awesome description of the request
+  #
+  # -- apib:response
+  # Some awesome description of the response
+  #
+  # ```json
+  # {}
+  # ```
+  # ---
+  #
+  # Not contained in the description
+  #
+  it 'has a custom description' do
+    # ...
+  end
+  ````
 
 ## Development
 
@@ -88,7 +135,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 To do continuous testing during development `guard` can be used. In order to
 test against multiple versions of Rails, the environment variable
 `RAILS_VERSION` can be used to choose a different dependency pattern then the
-default one specified in the *.gemspec* file.
+default one specified in the _.gemspec_ file.
 
 ```
 RAILS_VERSION='~> 4.0' bundle install; bundle exec rspec

--- a/lib/rspec/apib.rb
+++ b/lib/rspec/apib.rb
@@ -1,6 +1,7 @@
 require 'rails'
 require 'rspec/apib/version'
 require 'rspec/apib/configuration'
+require 'rspec/apib/comments_parser'
 require 'rspec/apib/recorder'
 require 'rspec/apib/writer'
 

--- a/lib/rspec/apib/comments_parser.rb
+++ b/lib/rspec/apib/comments_parser.rb
@@ -1,0 +1,60 @@
+module RSpec
+  module Apib
+    class CommentsParser
+      attr_reader :example
+
+      def initialize(example)
+        @example = example
+      end
+
+      def full_comment
+        line = example.metadata[:line_number]
+        return if line.nil? || line <= 0
+
+        lines = read_example_file
+        return if lines.count < line
+
+        i = line -2
+        result = []
+
+        while (i >= 0 && match = lines[i].match(/\A\s*#\s*(.*)/)) do
+          result.unshift(match[1])
+          i -= 1
+        end
+
+        result
+      end
+
+      def description(namespace = nil)
+        matcher = start_matcher(namespace)
+        comment = full_comment()
+        in_comment = false
+        return nil if comment.blank?
+
+        comment.select do |elem|
+          if elem == matcher
+            in_comment = true
+          elsif elem.match?(/\A---($|[^-])/)
+            in_comment = false
+          end
+
+          in_comment && elem != matcher
+        end.join("\n")
+      end
+
+      private
+
+      def read_example_file
+        file = example.metadata[:absolute_file_path]
+        return [] if file.nil? || file.empty?
+        return [] unless File.exists?(file)
+        IO.readlines(file)
+      end
+
+      def start_matcher(namespace)
+        return "--- apib" if namespace.blank?
+        "--- apib:#{namespace}"
+      end
+    end
+  end
+end

--- a/lib/rspec/apib/writer.rb
+++ b/lib/rspec/apib/writer.rb
@@ -52,6 +52,7 @@ module RSpec
             end
 
             apib += "+ Request\n\n"
+            apib += "#{data[:request][:description].indent(2, '  ')}\n\n" if data[:request][:description]
             apib += "    + Headers\n\n"
             data[:request][:headers].each do |header, value|
               apib += "            #{header}: #{value}\n"

--- a/spec/rspec/apib/comments_parser_spec.rb
+++ b/spec/rspec/apib/comments_parser_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+describe RSpec::Apib::CommentsParser do
+  describe '#full_comment' do
+    # ABC
+    #
+    # --- apib:response
+    # foo
+    # bar
+    # ---
+    #
+    # CDE
+    #
+    it 'returns the full comment of the example' do |example|
+      subject = described_class.new(example)
+      expect(subject.full_comment).to eql [
+        "ABC",
+        "",
+        "--- apib:response",
+        "foo",
+        "bar",
+        "---",
+        "",
+        "CDE",
+        "",
+      ]
+    end
+  end
+
+  describe '#description' do
+    # ABC
+    #
+    # --- apib:response
+    # foo
+    # bar
+    # --- apib
+    # baz
+    # ---
+    #
+    # CDE
+    #
+    it 'without a namespace, returns the `apib` comment' do |example|
+      subject = described_class.new(example)
+      expect(subject.description).to eql "baz"
+    end
+
+    # ABC
+    #
+    # --- apib:request
+    # foo
+    # bar
+    # --- apib
+    # baz
+    # ---
+    #
+    # CDE
+    #
+    it 'with a namespace, returns the `apib:NAMESPACE` comment' do |example|
+      subject = described_class.new(example)
+      expect(subject.description("request")).to eql "foo\nbar"
+    end
+
+    # --- apib
+    # FooBar
+    # ------
+    # Baz
+    # ---
+    it 'is not exiting on markdown headlines' do |example|
+      subject = described_class.new(example)
+      expect(subject.description).to eql "FooBar\n------\nBaz"
+    end
+  end
+end


### PR DESCRIPTION
Allow request annotations to be added to the documentation by commenting on the specs.