### PR TITLE
CHORE: add default_recording_policy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ RSpec::Apib.configure do |config|
 
   # Example types to record
   config.record_types = [:request]
+
+  # Recording policy
+
+  # The default recording policy is `true`. This results in a recording of
+  # all matching specs. By changing this policy to `false`, you can selectively
+  # include certain specs by adding `apib: true` to your example options.
+  #
+  # config.default_recording_policy = false
 end
 # ...
 RSpec::Apib.start

--- a/lib/rspec/apib.rb
+++ b/lib/rspec/apib.rb
@@ -23,11 +23,9 @@ module RSpec
       end
 
       def start
-        types = config.record_types
         RSpec.configure do |config|
           config.after :each do |example|
-            if types.include?(example.metadata[:type]) &&
-              !(example.metadata[:apib] === false)
+            if RSpec::Apib.record?(example)
               RSpec::Apib.record(example, request, response, @routes)
             end
           end
@@ -47,6 +45,15 @@ module RSpec
       def write
         writer = Writer.new(@_doc || {})
         writer.write
+      end
+
+      def record?(example)
+        default_recording_policy = config.default_recording_policy
+        config.record_types.include?(example.metadata[:type]) &&
+          (
+            default_recording_policy && !(example.metadata[:apib] === false) ||
+            !default_recording_policy && (example.metadata[:apib] === true)
+          )
       end
     end
   end

--- a/lib/rspec/apib/configuration.rb
+++ b/lib/rspec/apib/configuration.rb
@@ -2,7 +2,7 @@ module RSpec
   module Apib
     class Configuration < Struct.new(
       :dest_file, :pre_docs, :post_docs, :request_header_blacklist,
-      :request_param_blacklist, :record_types
+      :request_param_blacklist, :record_types, :default_recording_policy
     )
       def initialize
         self.pre_docs   = []
@@ -10,6 +10,7 @@ module RSpec
         self.request_header_blacklist = %w(host accept cookie)
         self.request_param_blacklist  = %i(controller action)
         self.record_types = %i(request)
+        self.default_recording_policy = true
       end
 
       def dest_file

--- a/spec/rspec/apib/configuration_spec.rb
+++ b/spec/rspec/apib/configuration_spec.rb
@@ -12,6 +12,8 @@ describe RSpec::Apib::Configuration do
   it { should respond_to :request_header_blacklist= }
   it { should respond_to :request_param_blacklist }
   it { should respond_to :request_param_blacklist= }
+  it { should respond_to :default_recording_policy }
+  it { should respond_to :default_recording_policy= }
 
   describe '#dest_file' do
     it 'equals the rails root by default' do
@@ -86,6 +88,13 @@ describe RSpec::Apib::Configuration do
     it 'equals the given value if it was an array' do
       subject.record_types = [:foo, :bar]
       expect(subject.record_types).to eql [:foo, :bar]
+    end
+  end
+
+  describe '#default_recording_policy' do
+    it 'contains the given value' do
+      subject.default_recording_policy = false
+      expect(subject.default_recording_policy).to eql false
     end
   end
 end


### PR DESCRIPTION
This allows to choose weather all specs should be recorded automatically, or only selected specs should be included into the documentation.